### PR TITLE
Necessary tweaks to simplify the tarball creation for v1.6.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ npm-debug.log
 .vscode
 *.log
 *.stackdump
+*.tgz

--- a/package.json
+++ b/package.json
@@ -22,5 +22,9 @@
     "lodash": "^4.17.21",
     "semver": "^7.3.5",
     "shelljs": "^0.8.5"
-  }
+  },
+  "files": [
+    "build/angular-mocks.js",
+    "build/angular.js"
+  ]
 }


### PR DESCRIPTION
# Problem

NPM runs build scripts of packages hosted on GitHub, which increases the installation time and is error-prone. However, NPM ignores the build scripts when installing a tarball package, even hosted on GitHub.

# Changes 

This patch makes necessary tweaks to simplify the tarball creation for the fork of Angular v1.6.10.