### PR TITLE
Necessary tweaks to simplify the tarball creation for v1.8.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ npm-debug.log
 *.stackdump
 scripts/docs.angularjs.org-firebase/functions/content
 /firebase.json
+*.tgz

--- a/package.json
+++ b/package.json
@@ -26,5 +26,9 @@
   },
   "resolutions": {
     "semver": "^7.5.4"
-  }
+  },
+  "files": [
+    "angular-mocks.js",
+    "angular.js"
+  ]
 }


### PR DESCRIPTION
# Problem

NPM runs build scripts of packages hosted on GitHub, which increases the installation time and is error-prone. However, NPM ignores the build scripts when installing a tarball package, even hosted on GitHub.

# Changes 

This patch makes necessary tweaks to simplify the tarball creation for the fork of Angular v1.8.2.